### PR TITLE
feat(xds): rs graph e2e

### DIFF
--- a/test/e2e/reachableservices/auto_reachable_services_k8s.go
+++ b/test/e2e/reachableservices/auto_reachable_services_k8s.go
@@ -79,13 +79,14 @@ spec:
 		}, "30s", "1s").Should(Succeed())
 
 		Consistently(func(g Gomega) {
-			_, _, err := client.CollectResponse(
+			failures, err := client.CollectFailure(
 				k8sCluster,
 				"second-test-server",
 				"first-test-server:80",
 				client.FromKubernetesPod(TestNamespace, "second-test-server"),
 			)
-			g.Expect(err).To(MatchError("command terminated with exit code 52"))
+			g.Expect(err).To(Not(HaveOccurred()))
+			g.Expect(failures.Exitcode).To(Equal(52))
 		}, "30s", "1s").Should(Succeed())
 	})
 }

--- a/test/e2e/reachableservices/auto_reachable_services_k8s.go
+++ b/test/e2e/reachableservices/auto_reachable_services_k8s.go
@@ -1,0 +1,96 @@
+package reachableservices
+
+import (
+	"fmt"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	config_core "github.com/kumahq/kuma/pkg/config/core"
+	. "github.com/kumahq/kuma/test/framework"
+	"github.com/kumahq/kuma/test/framework/deployments/testserver"
+	admintunnel "github.com/kumahq/kuma/test/framework/envoy_admin/tunnel"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"strings"
+)
+
+var k8sCluster Cluster
+
+var _ = E2EBeforeSuite(func() {
+	k8sCluster = NewK8sCluster(NewTestingT(), Kuma1, Silent)
+
+	err := NewClusterSetup().
+		Install(Kuma(config_core.Standalone,
+			WithEnv("KUMA_EXPERIMENTAL_AUTO_REACHABLE_SERVICES", "true"),
+		)).
+		Install(NamespaceWithSidecarInjection(TestNamespace)).
+		Install(testserver.Install(testserver.WithName("client-server"), testserver.WithMesh("default"))).
+		Install(testserver.Install(testserver.WithName("first-test-server"), testserver.WithMesh("default"))).
+		Install(testserver.Install(testserver.WithName("second-test-server"), testserver.WithMesh("default"))).
+		Setup(k8sCluster)
+
+	Expect(err).ToNot(HaveOccurred())
+
+	E2EDeferCleanup(func() {
+		Expect(k8sCluster.DeleteKuma()).To(Succeed())
+		Expect(k8sCluster.DismissCluster()).To(Succeed())
+	})
+})
+
+func AutoReachableServices() {
+	removeDefaultTrafficPermission := func() {
+		err := k8s.RunKubectlE(k8sCluster.GetTesting(), k8sCluster.GetKubectlOptions(), "delete", "trafficpermission", "allow-all-default")
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	noDefaultTrafficPermission := func() {
+		Eventually(func() bool {
+			out, err := k8s.RunKubectlAndGetOutputE(k8sCluster.GetTesting(), k8sCluster.GetKubectlOptions(), "get", "trafficpermissions")
+			if err != nil {
+				return false
+			}
+			return !strings.Contains(out, "allow-all-default")
+		}, "30s", "1s").Should(BeTrue())
+	}
+
+	It("should not connect to non auto reachable service", func() {
+		// when
+		removeDefaultTrafficPermission()
+		// then
+		noDefaultTrafficPermission()
+
+		// when
+		Expect(YamlK8s(fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: MeshTrafficPermission
+metadata:
+  name: mtp1
+  namespace: %s
+  labels:
+    kuma.io/mesh: default
+spec:
+  targetRef:
+    kind: MeshService
+    name: first-test-server_kuma-test_svc_80
+  from:
+    - targetRef:
+        kind: Mesh
+      default:
+        action: Deny
+    - targetRef:
+        kind: MeshService
+        name: client-server_kuma-test_svc_80
+      default:
+        action: Allow
+`, Config.KumaNamespace))(k8sCluster)).To(Succeed())
+
+		secondServerPod, err := PodNameOfApp(k8sCluster, "second-test-server", TestNamespace)
+		Expect(err).ToNot(HaveOccurred())
+		secondServerTunnel := k8s.NewTunnel(k8sCluster.GetKubectlOptions(TestNamespace), k8s.ResourceTypePod, secondServerPod, 0, 9901)
+		secondServerTunnel.ForwardPort(k8sCluster.GetTesting())
+		secondServerAdmin := admintunnel.NewK8sEnvoyAdminTunnel(k8sCluster.GetTesting(), secondServerTunnel.Endpoint())
+
+		// then
+		stat, err := secondServerAdmin.GetStats("first-test-server_kuma-test_svc_80::added_via_api::true")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stat.Stats).To(HaveLen(0))
+	})
+}

--- a/test/e2e/reachableservices/e2e_suite_test.go
+++ b/test/e2e/reachableservices/e2e_suite_test.go
@@ -1,0 +1,16 @@
+package reachableservices_test
+
+import (
+	"github.com/kumahq/kuma/test/e2e/reachableservices"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/kumahq/kuma/pkg/test"
+)
+
+func TestE2E(t *testing.T) {
+	test.RunE2ESpecs(t, "E2E Auto Reachable Services Kubernetes Suite")
+}
+
+var _ = Describe("Auto Reachable Services on Kubernetes", Label("job-1"), reachableservices.AutoReachableServices)


### PR DESCRIPTION
### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Fix ...]

### Issues resolved

Fix #XXX

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/kumahq/kuma-website/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

### Backwards compatibility

- [ ] Update [`UPGRADE.md`](/UPGRADE.md) with any steps users will need to take when upgrading.
- [ ] Add `backport-to-stable` label if the code follows our [backporting policy](/CONTRIBUTING.md#backporting)
